### PR TITLE
--quiet がうまく動かなかったため -s を用いるように修正

### DIFF
--- a/git-ls-branches
+++ b/git-ls-branches
@@ -161,7 +161,7 @@ main () {
             echo "$hash:$sign:$branch:$link:$rest" >> "$finfo"
             printf "$branch\000"
         }
-    done | xargs -0 git show --quiet --format="%H %ct $ptimef" | {
+    done | xargs -0 git show -s --format="%H %ct $ptimef" | {
         while IFS=' ' read -r hash time ptime; do
             eval "
 time_$hash=\"\$time\"


### PR DESCRIPTION
--quiet が正しく動くのは 1.8 からのようであるため， -s を使って 1.7 でも動くように修正してみました．

https://github.com/git/git/blob/master/Documentation/RelNotes/1.8.0.txt#L256

追記） 1.7.12.1 よりも前のバージョンのようでした．
https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.12.1.txt#L59
### 確認環境

```
$ cat /etc/issue
Ubuntu 12.04.2 LTS \n \l
$ git --version
git version 1.7.9.5
```
