### PR TITLE
Use “--get-color z” instead of “--get-color=z” as arguments

### DIFF
--- a/git-ls-branches
+++ b/git-ls-branches
@@ -122,11 +122,11 @@ main () {
 
     shift "$((OPTIND-1))"
 
-    if git config --get-colorbool=color.branch $color >/dev/null; then
+    if git config --get-colorbool color.branch $color >/dev/null; then
         ptimef="%Cblue($timef)%Creset"
-        cbranchf="$(git config --get-color=color.branch.current green)%s\033[m"
-        lbranchf="$(git config --get-color=color.branch.local normal)%s\033[m"
-        rbranchf="$(git config --get-color=color.branch.remote red)%s\033[m"
+        cbranchf="$(git config --get-color color.branch.current green)%s\033[m"
+        lbranchf="$(git config --get-color color.branch.local normal)%s\033[m"
+        rbranchf="$(git config --get-color color.branch.remote red)%s\033[m"
     else
         ptimef="($timef)"
         cbranchf="%s"


### PR DESCRIPTION
Hi.
I really like this `ls-branches` command.
But after my git was updated to version 2.4, ls-branches stopped working.
It looks like the new git versions require a space, not a “=” between a long argument name and its value, at least for `--get-color`

This works for all git versions i have on my different systems, one old, `git version 1.7.10.4`, and two rather new ones, 2.4.3 and 2.5.1.
